### PR TITLE
feat: add --metrics-batch-size command-line parameter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,9 @@ struct Cli {
 
     #[arg(short, long, value_enum)]
     scheduler: Scheduler,
+    
+    #[arg(long, default_value = "10")]
+    metrics_batch_size: usize,
 }
 
 #[derive(clap::ValueEnum, Clone, Debug)]
@@ -80,7 +83,7 @@ fn main() -> Result<()> {
     let hypervisor = Arc::new(Hypervisor::new(scheduler, Duration::from_secs(1)));
 
     let gpu_observer = GpuObserver::create(nvml.clone(), Duration::from_secs(1));
-    metrics::output_metrics(gpu_observer.clone(), hypervisor.clone());
+    metrics::output_metrics(gpu_observer.clone(), hypervisor.clone(), cli.metrics_batch_size);
     let _ = std::thread::Builder::new()
         .name("worker watcher".into())
         .spawn({

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -18,7 +18,7 @@ struct AccumulatedWorkerMetrics {
     count: usize,
 }
 
-pub(crate) fn output_metrics(gpu_observer: Arc<GpuObserver>, hypervisor: Arc<Hypervisor>) {
+pub(crate) fn output_metrics(gpu_observer: Arc<GpuObserver>, hypervisor: Arc<Hypervisor>, metrics_batch_size: usize) {
     let receiver = gpu_observer.subscribe();
     let _ = std::thread::Builder::new()
         .name("output metrics".into())
@@ -54,8 +54,8 @@ pub(crate) fn output_metrics(gpu_observer: Arc<GpuObserver>, hypervisor: Arc<Hyp
                         }
                     }
 
-                    // Output averaged metrics every 10 iterations
-                    if counter >= 10 {
+                    // Output averaged metrics every metrics_batch_size iterations
+                    if counter >= metrics_batch_size {
                         // Output averaged PCIE metrics
                         for (gpu_uuid, acc) in &gpu_acc {
                             if acc.count > 0 {


### PR DESCRIPTION
Add `--metrics-batch-size` command-line parameter to allow configuring the number of iterations over which metrics are aggregated before calculating and outputting averages.