### PR TITLE
feat(hypervisor): add TUI for monitoring workers and update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,10 +348,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -485,6 +500,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +616,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.9.1",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -938,6 +992,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1255,11 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "headers"
@@ -1473,10 +1538,12 @@ dependencies = [
  "chrono",
  "clap",
  "criterion",
+ "crossterm",
  "cudarc",
  "derive_more",
  "error-stack",
  "futures",
+ "glob",
  "http-bidir-comm",
  "hyper-util",
  "influxdb-line-protocol",
@@ -1488,6 +1555,7 @@ dependencies = [
  "once_cell",
  "poem",
  "priority-queue",
+ "ratatui",
  "schemars",
  "serde",
  "serde_json",
@@ -1654,6 +1722,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "influxdb-line-protocol"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1758,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2060,6 +2147,15 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.4",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2794,6 +2890,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.9.1",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3302,6 +3419,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,6 +3553,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "subtle"
@@ -3966,6 +4126,29 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/hypervisor/Cargo.toml
+++ b/crates/hypervisor/Cargo.toml
@@ -38,6 +38,9 @@ schemars = { workspace = true }
 notify = "8.1"
 cudarc = { workspace = true, features = ["std", "driver", "dynamic-loading", "cuda-11080"] }
 libc = { workspace = true }
+ratatui = "0.29"
+crossterm = "0.28"
+glob = "0.3"
 
 [[bin]]
 name = "hypervisor"

--- a/crates/hypervisor/src/config.rs
+++ b/crates/hypervisor/src/config.rs
@@ -26,12 +26,25 @@ pub enum Commands {
     /// Show shared memory state
     #[command(name = "show-shm")]
     ShowShm(ShowShmArgs),
+    /// Show TUI for monitoring workers
+    #[command(name = "show-tui-workers")]
+    ShowTuiWorkers(ShowTuiWorkersArgs),
 }
 
 #[derive(Parser)]
 pub struct ShowShmArgs {
     #[arg(long, help = "Shared memory identifier")]
     pub shm_identifier: String,
+}
+
+#[derive(Parser)]
+pub struct ShowTuiWorkersArgs {
+    #[arg(
+        long,
+        help = "Glob pattern for worker shared memory files",
+        default_value = "/tf_shm_*"
+    )]
+    pub glob: String,
 }
 
 #[derive(Parser)]

--- a/crates/hypervisor/src/main.rs
+++ b/crates/hypervisor/src/main.rs
@@ -15,6 +15,7 @@ mod metrics;
 mod pod_management;
 mod process;
 mod scheduler;
+mod tui_workers;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -44,6 +45,9 @@ async fn main() -> Result<()> {
         Commands::Daemon(daemon_args) => run_daemon(*daemon_args).await,
         Commands::MountShm(mount_shm_args) => run_mount_shm(mount_shm_args).await,
         Commands::ShowShm(show_shm_args) => run_show_shm(show_shm_args).await,
+        Commands::ShowTuiWorkers(show_tui_workers_args) => {
+            run_show_tui_workers(show_tui_workers_args).await
+        }
     }
 }
 
@@ -196,4 +200,12 @@ async fn run_mount_shm(mount_shm_args: crate::config::MountShmArgs) -> Result<()
     }
 
     Ok(())
+}
+
+async fn run_show_tui_workers(args: crate::config::ShowTuiWorkersArgs) -> Result<()> {
+    utils::logging::init();
+
+    tracing::info!("Starting TUI worker monitor with pattern: {}", args.glob);
+
+    tui_workers::run_tui_monitor(format!("/dev/shm/{}", args.glob)).await
 }

--- a/crates/hypervisor/src/tui_workers.rs
+++ b/crates/hypervisor/src/tui_workers.rs
@@ -1,0 +1,330 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use crossterm::ExecutableCommand;
+use glob::glob;
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Cell, Row, Table, TableState};
+use tokio::sync::mpsc;
+use utils::shared_memory::handle::SharedMemoryHandle;
+
+#[derive(Debug, Clone)]
+pub struct WorkerInfo {
+    pub identifier: String,
+    pub ref_count: u32,
+    pub last_heartbeat: u64,
+    pub device_count: usize,
+    pub is_healthy: bool,
+    pub file_path: String,
+}
+
+pub struct WorkerMonitor {
+    workers: HashMap<String, WorkerInfo>,
+    table_state: TableState,
+    selected_index: usize,
+}
+
+impl WorkerMonitor {
+    pub fn new() -> Self {
+        Self {
+            workers: HashMap::new(),
+            table_state: TableState::default(),
+            selected_index: 0,
+        }
+    }
+
+    pub fn update_workers(&mut self, pattern: &str) -> Result<()> {
+        let mut new_workers = HashMap::new();
+
+        for entry in glob(pattern).context("Failed to parse glob pattern")? {
+            let path = entry.context("Failed to read glob entry")?;
+
+            if !path.is_file() {
+                continue;
+            }
+
+            let identifier = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("")
+                .to_string();
+
+            if identifier.is_empty() {
+                continue;
+            }
+
+            match self.read_worker_info(&identifier, &path) {
+                Ok(info) => {
+                    new_workers.insert(identifier.clone(), info);
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to read worker {}: {}", identifier, e);
+                    continue;
+                }
+            }
+        }
+
+        self.workers = new_workers;
+        self.update_selection();
+        Ok(())
+    }
+
+    fn read_worker_info(&self, identifier: &str, path: &Path) -> Result<WorkerInfo> {
+        let handle =
+            SharedMemoryHandle::open(identifier).context("Failed to open shared memory")?;
+
+        let state = handle.get_state();
+        let (ref_count, last_heartbeat, device_count, is_healthy) = (
+            state.get_ref_count(),
+            state.get_last_heartbeat(),
+            state.device_count(),
+            state.is_healthy(60), // 60 seconds timeout
+        );
+
+        Ok(WorkerInfo {
+            identifier: identifier.to_string(),
+            ref_count,
+            last_heartbeat,
+            device_count,
+            is_healthy,
+            file_path: path.display().to_string(),
+        })
+    }
+
+    fn update_selection(&mut self) {
+        let worker_count = self.workers.len();
+        if worker_count == 0 {
+            self.selected_index = 0;
+            self.table_state.select(None);
+        } else {
+            if self.selected_index >= worker_count {
+                self.selected_index = worker_count - 1;
+            }
+            self.table_state.select(Some(self.selected_index));
+        }
+    }
+
+    pub fn next(&mut self) {
+        let worker_count = self.workers.len();
+        if worker_count > 0 {
+            self.selected_index = (self.selected_index + 1) % worker_count;
+            self.table_state.select(Some(self.selected_index));
+        }
+    }
+
+    pub fn previous(&mut self) {
+        let worker_count = self.workers.len();
+        if worker_count > 0 {
+            if self.selected_index == 0 {
+                self.selected_index = worker_count - 1;
+            } else {
+                self.selected_index -= 1;
+            }
+            self.table_state.select(Some(self.selected_index));
+        }
+    }
+
+    pub fn render(&mut self, frame: &mut Frame) {
+        let area = frame.area();
+
+        let header_cells = [
+            "Identifier",
+            "Ref Count",
+            "Devices",
+            "Health",
+            "Last Heartbeat",
+            "File Path",
+        ]
+        .iter()
+        .map(|h| Cell::from(*h).style(Style::default().fg(Color::Yellow)));
+
+        let header = Row::new(header_cells).height(1).bottom_margin(1);
+
+        let mut rows: Vec<_> = self.workers.values().collect();
+        rows.sort_by(|a, b| a.identifier.cmp(&b.identifier));
+
+        let data_rows = rows.iter().map(|worker| {
+            let health_status = if worker.is_healthy {
+                "Healthy"
+            } else {
+                "Unhealthy"
+            };
+            let health_color = if worker.is_healthy {
+                Color::Green
+            } else {
+                Color::Red
+            };
+
+            let heartbeat_time = if worker.last_heartbeat == 0 {
+                "Never".to_string()
+            } else {
+                match SystemTime::now().duration_since(UNIX_EPOCH) {
+                    Ok(now) => {
+                        let elapsed = now.as_secs().saturating_sub(worker.last_heartbeat);
+                        format!("{}s ago", elapsed)
+                    }
+                    Err(_) => "Unknown".to_string(),
+                }
+            };
+
+            Row::new(vec![
+                Cell::from(worker.identifier.as_str()),
+                Cell::from(worker.ref_count.to_string()),
+                Cell::from(worker.device_count.to_string()),
+                Cell::from(health_status).style(Style::default().fg(health_color)),
+                Cell::from(heartbeat_time),
+                Cell::from(worker.file_path.as_str()),
+            ])
+        });
+
+        let widths = [
+            Constraint::Length(20),
+            Constraint::Length(10),
+            Constraint::Length(8),
+            Constraint::Length(10),
+            Constraint::Length(15),
+            Constraint::Fill(1),
+        ];
+
+        let table = Table::new(data_rows, widths)
+            .header(header)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(format!(" Worker Monitor ({} workers) ", self.workers.len())),
+            )
+            .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+            .highlight_symbol(">> ");
+
+        frame.render_stateful_widget(table, area, &mut self.table_state);
+    }
+}
+
+pub async fn run_tui_monitor(glob_pattern: String) -> Result<()> {
+    let mut stdout = std::io::stdout();
+    enable_raw_mode()?;
+    stdout.execute(EnterAlternateScreen)?;
+
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut monitor = WorkerMonitor::new();
+
+    let (tx, mut rx) = mpsc::channel(100);
+
+    let pattern_clone = glob_pattern.clone();
+    let tx_clone = tx.clone();
+    let _watcher_task = tokio::spawn(async move {
+        if let Err(e) = setup_file_watcher(&pattern_clone, tx_clone).await {
+            tracing::error!("File watcher error: {}", e);
+        }
+    });
+
+    let tx_clone = tx.clone();
+    let _pattern_clone = glob_pattern.clone();
+    let _refresh_task = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(5));
+        loop {
+            interval.tick().await;
+            if tx_clone.send(RefreshEvent::Timer).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    monitor.update_workers(&glob_pattern)?;
+
+    let result = run_ui_loop(&mut terminal, &mut monitor, &mut rx, &glob_pattern).await;
+
+    disable_raw_mode()?;
+    terminal.backend_mut().execute(LeaveAlternateScreen)?;
+
+    result
+}
+
+#[derive(Debug)]
+enum RefreshEvent {
+    FileChange,
+    Timer,
+}
+
+async fn setup_file_watcher(pattern: &str, tx: mpsc::Sender<RefreshEvent>) -> Result<()> {
+    let path = if pattern.starts_with("/dev/shm/") {
+        "/dev/shm"
+    } else {
+        pattern.split('/').next().unwrap_or("/dev/shm")
+    };
+
+    let (watch_tx, mut watch_rx) = mpsc::channel(100);
+    let mut watcher = RecommendedWatcher::new(
+        move |res| {
+            if let Ok(event) = res {
+                if let Err(_) = watch_tx.blocking_send(event) {}
+            }
+        },
+        notify::Config::default(),
+    )?;
+
+    watcher.watch(Path::new(path), RecursiveMode::NonRecursive)?;
+
+    while let Some(_event) = watch_rx.recv().await {
+        if tx.send(RefreshEvent::FileChange).await.is_err() {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_ui_loop(
+    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    monitor: &mut WorkerMonitor,
+    rx: &mut mpsc::Receiver<RefreshEvent>,
+    glob_pattern: &str,
+) -> Result<()> {
+    loop {
+        terminal.draw(|f| monitor.render(f))?;
+
+        tokio::select! {
+            event = tokio::time::timeout(Duration::from_millis(100), async { event::read() }) => {
+                match event {
+                    Ok(Ok(Event::Key(key))) if key.kind == KeyEventKind::Press => {
+                        match key.code {
+                            KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                            KeyCode::Down | KeyCode::Char('j') => monitor.next(),
+                            KeyCode::Up | KeyCode::Char('k') => monitor.previous(),
+                            KeyCode::Char('r') => {
+                                if let Err(e) = monitor.update_workers(glob_pattern) {
+                                    tracing::error!("Failed to update workers: {}", e);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    Ok(Err(e)) => {
+                        tracing::error!("Terminal event error: {}", e);
+                    }
+                    Err(_) => {} // Timeout
+                    _ => {}
+                }
+            }
+            refresh_event = rx.recv() => {
+                match refresh_event {
+                    Some(RefreshEvent::FileChange) | Some(RefreshEvent::Timer) => {
+                        if let Err(e) = monitor.update_workers(glob_pattern) {
+                            tracing::error!("Failed to update workers: {}", e);
+                        }
+                    }
+                    None => return Ok(()),
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Introduced a new command `show-tui-workers` to display a TUI for monitoring worker states.
- Added a new module `tui_workers` to handle the TUI logic.
- Updated `Cargo.toml` to include dependencies on `ratatui`, `crossterm`, and `glob`.
- Enhanced the worker registration process to support TUI functionality.